### PR TITLE
install standard library

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,18 @@ Unnecessary files have been deleted, and the build system has been replaced
 with `build.zig`. There are no system dependencies; the only thing required to
 build this package is [Zig](https://ziglang.org/download/).
 
-This builds a static executable, which can be then executed like this:
-```
-PYTHONPATH=Lib zig-out/bin/cpython
-```
+A static executable will be built when targeting musl (i.e. `x86_64-linux-musl`).
+
+### Runtime Libraries
+
+Python requires library files at runtime, it looks for them using a list of candidates
+combined with the executable's filesystem path and environment variables, i.e.
+
+- `<EXECUTABLE_PATH>/lib/python3.11`
+- `<EXECUTABLE_PATH>/../lib/python3.11`
+- `$PYTHONHOME/lib/python3.11`
+
+The build will install them to `$libdir/python3.11` which cpython should find.
 
 ## Project Status
 

--- a/build.zig
+++ b/build.zig
@@ -834,6 +834,17 @@ pub fn build(b: *std.Build) void {
         "-DSOABI=\"cpython-311-x86_64-linux-gnu\"",
     } });
     b.installArtifact(exe);
+
+    const write_files = b.addWriteFiles();
+    _ = write_files.addCopyDirectory(b.path("Lib"), "", .{});
+    const empty_dir = b.addWriteFiles().getDirectory();
+    _ = write_files.addCopyDirectory(empty_dir, "lib-dynload", .{});
+    const install_lib = b.addInstallDirectory(.{
+        .source_dir = write_files.getDirectory(),
+        .install_dir = .lib,
+        .install_subdir = "python3.11",
+    });
+    b.getInstallStep().dependOn(&install_lib.step);
 }
 
 fn have(x: bool) ?u1 {


### PR DESCRIPTION
Installs the standard platform independent libraries from Lib. Also updates README.md to clarify how python will try to find these files, in most cases they should be found automatically.

Also updates the README to clarify that a static executable will only be built with the musl (gnu produces a dynamic exe) as this sentence was a part of the docs on runtime libraries.